### PR TITLE
Fixed hollowout example's use of TriangleModelCreator

### DIFF
--- a/apps/hollowout/src/java/hollowout/HollowOut.java
+++ b/apps/hollowout/src/java/hollowout/HollowOut.java
@@ -74,16 +74,15 @@ public class HollowOut {
         TriangleModelCreator tmc = null;
 
         double rx = 0,ry = 1,rz = 0,rangle = 0;
-        int outerMaterial = 1;
-        int innerMaterial = 1;
+        long innerMaterial = 1;
 
 
         tmc = new TriangleModelCreator(geom,x,y,z,
-            rx,ry,rz,rangle,outerMaterial,innerMaterial,false);
+            rx,ry,rz,rangle,innerMaterial,false);
 
         tmc.generate(grid);
 
-        ThickenUniform op = new ThickenUniform(outerMaterial);
+        ThickenUniform op = new ThickenUniform(innerMaterial);
 
         for(int i=0; i < thickenPasses; i++) {
             op.execute(grid);


### PR DESCRIPTION
TriangleModelCreator's signature changed twice, in 019b01861e03ba8a32d7f152bdf8406feb37b91c and
0dc9de628d0b3395e713c22e67a19758e449350f, without this example being updated. This fixes it.
