### PR TITLE
Laplacian Smoothing: Avoid ArrayOutOfBoundsException in case of nonmanifold edge

### DIFF
--- a/src/java/abfab3d/mesh/LaplasianSmooth.java
+++ b/src/java/abfab3d/mesh/LaplasianSmooth.java
@@ -116,6 +116,9 @@ public class LaplasianSmooth {
                 count++;
 
                 int twin = HalfEdge.getTwin(hedges,he);
+                if (twin == -1) {
+                    break;
+                }
 
                 he = HalfEdge.getNext(hedges,twin);
 


### PR DESCRIPTION
Passing -1 into HalfEdge.getNext(hedges, twin) throws an ArrayOutOfBoundsException.
